### PR TITLE
Fixed wrong naming of text to ASCII to text to decimal

### DIFF
--- a/tools/index.html
+++ b/tools/index.html
@@ -61,7 +61,7 @@
             </div>
             <div class="bg-gray-800 rounded-lg shadow-md p-6">
                 <h2 class="text-2xl font-semibold mb-4 text-white">TTA</h2>
-                <p class="mb-4 text-gray-300">ascii to text</p>
+                <p class="mb-4 text-gray-300">Text to decimal</p>
                 <a href="https://Daradege.github.io/tools/tta" target="_blank" class="btn btn-primary">Open Tool</a>
                 <button class="btn btn-secondary mt-2" onclick="captureScreenshot('https://Daradege.github.io/tools/tta')">Capture Screenshot</button>
             </div>

--- a/tools/tta/index.html
+++ b/tools/tta/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Text to ASCII Converter</title>
+    <title>Text to decimal Converter</title>
     <style>
         body {
             font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
@@ -48,35 +48,35 @@
     </style>
 </head>
 <body>
-    <h1>Text ↔ ASCII Converter</h1>
+    <h1>Text ↔ Decimal Converter</h1>
     
     <div class="container">
         <h3>Text Input</h3>
-        <textarea id="textInput" placeholder="Enter your text here..." oninput="convertToAscii()"></textarea>
+        <textarea id="textInput" placeholder="Enter your text here..." oninput="convertToDecimal()"></textarea>
     </div>
 
     <div class="container">
-        <h3>ASCII Output</h3>
-        <textarea id="asciiOutput" placeholder="ASCII values will appear here..." oninput="convertToText()"></textarea>
+        <h3>Decimal Output</h3>
+        <textarea id="decimalOutput" placeholder="Decimal values will appear here..." oninput="convertToText()"></textarea>
     </div>
 
     <script>
-        function convertToAscii() {
+        function convertToDecimal() {
             const text = document.getElementById('textInput').value;
-            const ascii = text.split('').map(char => char.charCodeAt(0)).join(' ');
-            document.getElementById('asciiOutput').value = ascii;
+            const decimal = text.split('').map(char => char.charCodeAt(0)).join(' ');
+            document.getElementById('decimalOutput').value = decimal;
         }
 
         function convertToText() {
-            const ascii = document.getElementById('asciiOutput').value;
+            const decimal = document.getElementById('decimalOutput').value;
             try {
-                const text = ascii.split(' ')
+                const text = decimal.split(' ')
                     .filter(num => num.trim() !== '')
                     .map(num => String.fromCharCode(parseInt(num)))
                     .join('');
                 document.getElementById('textInput').value = text;
             } catch (e) {
-                document.getElementById('textInput').value = 'Invalid ASCII values';
+                document.getElementById('textInput').value = 'Invalid Decimal values';
             }
         }
     </script>


### PR DESCRIPTION
reasons for this change:
1. ASCII is not always in decimal (1-9) form and could be represented in any numbering system e.g. hexadecimal or roman numerals
2. `String.charCodeAt` is not limited to ASCII text and could convert any UTF-16 compatible text to int form (Unicode is compatible with ASCII and UTF-16 is an unicode encoding)